### PR TITLE
Transitively reduce imports

### DIFF
--- a/priv/algstruct.ctt
+++ b/priv/algstruct.ctt
@@ -1,11 +1,8 @@
 -- This file contains the definitions of some standard algebraic structures
 -- and homomorphisms, as well as some related identities.
 module algstruct where
-import bool
-import prelude
 import pi_prev
 import iso_sigma
-import sigma
 
 -- Properties
 --------------------------------------------------------------------------------

--- a/priv/circle.ctt
+++ b/priv/circle.ctt
@@ -1,7 +1,6 @@
 -- The circle as a HIT.
 module circle where
 
-import bool
 import int
 
 data S1 = base

--- a/priv/collection.ctt
+++ b/priv/collection.ctt
@@ -1,7 +1,6 @@
 -- This file proves that the collection of all sets is a groupoid
 module collection where
 
-import univ
 import sigma_prev
 import pi_prev
 

--- a/priv/helix.ctt
+++ b/priv/helix.ctt
@@ -2,7 +2,6 @@
 module helix where
 
 import circle
-import equiv
 import pi
 
 oneTurn (l: loopS1) : loopS1 = compS1 l loop1

--- a/priv/iso_example.ctt
+++ b/priv/iso_example.ctt
@@ -1,7 +1,6 @@
 module iso_example where
 
 import nat
-import iso
 
 data nat2 = zero2 | suc2 (n : nat2)
 

--- a/priv/lambek.ctt
+++ b/priv/lambek.ctt
@@ -1,6 +1,5 @@
 module lambek where
 
-import functor
 import control
 import either
 import nat

--- a/priv/list.ctt
+++ b/priv/list.ctt
@@ -1,11 +1,8 @@
 module list where
 
 import nat
-import prelude
 import control
 import maybe
-import bool
-import eq
 
 data list (A: U) = nil
                  | cons (a: A) (as: list A)

--- a/priv/nat.ctt
+++ b/priv/nat.ctt
@@ -1,6 +1,5 @@
 module nat where
 
-import bool
 import eq
 
 data nat = zero | suc (n : nat)

--- a/priv/om.ctt
+++ b/priv/om.ctt
@@ -1,9 +1,6 @@
 module om where
 
-import nat
 import list
-import maybe
-import sigma
 
 data alg = z | o | max (a b: alg) | min (a b: alg) | app (a b: alg)
 name: U = list nat

--- a/priv/puresigma.ctt
+++ b/priv/puresigma.ctt
@@ -1,5 +1,4 @@
 module puresigma where
-import nat
 import list
 
 P: nat -> U = (\(_:nat) -> list nat)

--- a/priv/setquot.ctt
+++ b/priv/setquot.ctt
@@ -1,7 +1,6 @@
 -- Formalization of (impredicative) set quotients
 module setquot where
 
-import bool
 import sigma_prev
 import pi_prev
 

--- a/redundant_deps
+++ b/redundant_deps
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+current=$(mktemp)
+reduced=$(mktemp)
+trap "rm $current $reduced" EXIT
+
+(cd priv; ls -1 *.ctt) > distinct.txt 
+./makedot > $current
+./makedot | tred >$reduced
+diff -uw <(sort $current) <(sort $reduced|sed -e's/;//')

--- a/test
+++ b/test
@@ -10,11 +10,13 @@ files="binnat function
        univalence category grothendieck"
 
 rm parsed.txt
-for file in $files
-do
- grep "^import $file$" priv/*.ctt
- cubical -b priv/$file.ctt | tee >(grep Parsed | sed 's|Parsed "priv/||;s|" successfully!||' >>parsed.txt) | grep -vE "0m0|^ *Checking:|^Parsed|File loaded.|^$|cubical, version|shadowed"
-done
+function compile() {
+    file="$1"
+    grep "^import $file$" priv/*.ctt
+    cubical -b priv/$file.ctt 
+}
+export -f compile
+parallel compile ::: $files | tee >(grep Parsed | sed 's|Parsed "priv/||;s|" successfully!||' >>parsed.txt) | grep -vE "0m0|^ *Checking:|^Parsed|File loaded.|^$|cubical, version|shadowed"
 
 echo Compiled $(sort -u parsed.txt | wc -l) files of $(ls -1 priv/*.ctt | wc -l) in priv/
 echo Skipped files:


### PR DESCRIPTION
    computed via:
    
    (cd priv; ls -1 *.ctt) >| distinct.txt
    ./makedot >| current.dot
    ./makedot | tred >| reduced.dot
    diff -uw <(sort current.dot) <(sort reduced.dot|sed -e's/;//')
